### PR TITLE
0.1.7 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,4 @@ SECRET_ALGOD_ADMIN_TOKEN="Can be found in <ALGORAND_DATA>/algod.admin.token"
 # DASHBOARD FEATURES
 # =========================================================
 PUBLIC_CHECK_VERSION_ON_GITHUB=true
+PUBLIC_ALLOW_EXTERNAL_APIS=true

--- a/bin/setup/prompts.js
+++ b/bin/setup/prompts.js
@@ -143,7 +143,7 @@ export function promptFeaturesConfigs() {
       message: `Allow external API calls to fetch statistics about your node?
         ${ chalk.reset(`(default: Yes)`) }
       `,
-      name: 'PUBLIC_ALLOW_EXTERNAL_API',
+      name: 'PUBLIC_ALLOW_EXTERNAL_APIS',
       type: 'confirm',
       default: true,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "alloctrl",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "alloctrl",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"algostack": "^0.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "alloctrl",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"type": "module",
 	"license": "BSD-3-Clause",
 	"module": "./build/index.js",

--- a/src/components/blocks/dashboard/CurrentVersion.svelte
+++ b/src/components/blocks/dashboard/CurrentVersion.svelte
@@ -1,34 +1,37 @@
 <script lang="ts">
-  import { ErrorCode } from "$lib/enums";
+  import { ErrorCode, NodeState } from "$lib/enums";
   import __ from "$lib/locales";
   import Prop from "$components/elements/Prop.svelte";
   import ErrorCard from "$components/elements/ErrorCard.svelte";
-  import { getCurrentVersion } from "$lib/stores/status";
+  import status, { getCurrentVersion } from "$lib/stores/status";
   import Skeleton from "$components/elements/Skeleton.svelte";
 </script>
 
-{#await getCurrentVersion }
-  <Skeleton height="8em" />
+
+{#if $status.state === NodeState.READY }
+  {#await getCurrentVersion }
+    <Skeleton height="8em" />
 
 
-{:then version }
-  <section class="card">
-    <h3 class="card-header card-title">
-      { __('versions.version') }
-    </h3>
+  {:then version }
+    <section class="card">
+      <h3 class="card-header card-title">
+        { __('versions.version') }
+      </h3>
 
-    <div class="card-content">
-      <div class="current">
-        <Prop 
-          label={ __('versions.current') }
-          value={ version }
-        />
+      <div class="card-content">
+        <div class="current">
+          <Prop 
+            label={ __('versions.current') }
+            value={ version }
+          />
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
 
 
-{:catch error }
-  <ErrorCard code={ ErrorCode.API_NOT_RESPONDING } />
+  {:catch error }
+    <ErrorCard code={ ErrorCode.API_NOT_RESPONDING } />
 
-{/await}
+  {/await}
+{/if}

--- a/src/components/blocks/dashboard/Metrics.svelte
+++ b/src/components/blocks/dashboard/Metrics.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ErrorCode, PropType, Sizes } from "$lib/enums";
+  import { parseMetricsResponse } from "$lib/helpers/responses";
   import __ from "$lib/locales";
   import ErrorCard from "$components/elements/ErrorCard.svelte";
   import Skeleton from "$components/elements/Skeleton.svelte";
@@ -7,20 +8,8 @@
   import Prop from "$components/elements/Prop.svelte";
 
   async function init() {
-    const metrics: Record<string, number> = {};
     const response = await AlgodApi.private.get('/metrics') as string;
-    response
-      .replace(/^#.+/gm, '') // remove comments
-      .replace(/\n+/g, '\n') // merge multiple new lines
-      .replace(/^\n/g, '') // remove empty new line
-      .replace(/{}/g, '') // remove curly braces
-      .split('\n')
-      .forEach((str: string) => {
-        const [key, value] = str.split(' ');
-        
-        metrics[key] = Number(value);
-      });
-
+    const metrics = parseMetricsResponse(response);
     return metrics
   }
 </script>

--- a/src/components/blocks/dashboard/VersionCheck.svelte
+++ b/src/components/blocks/dashboard/VersionCheck.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ErrorCode } from "$lib/enums";
+  import { ErrorCode, NodeState } from "$lib/enums";
   import __ from "$lib/locales";
   import axios from "axios";
   import Prop from "$components/elements/Prop.svelte";
@@ -7,7 +7,7 @@
   import status, { getCurrentVersion } from "$lib/stores/status";
   import Icon from "$components/icons/Icon.svelte";
   import Skeleton from "$components/elements/Skeleton.svelte";
-    import CurrentVersion from "./CurrentVersion.svelte";
+  import CurrentVersion from "./CurrentVersion.svelte";
 
   const githubLatestReleaseUrl = 'https://api.github.com/repos/algorand/go-algorand/releases/latest';
 
@@ -30,54 +30,55 @@
 </script>
 
 
+{#if $status.state === NodeState.READY }
+  {#await init() }
+    <Skeleton height="8em" />
 
-{#await init() }
-  <Skeleton height="8em" />
 
+  {:then { isLatest, latest } }
+    <section class="card">
+      <h3 class="card-header card-title">
+        {#if isLatest }
+          <Icon name="ok" />
+          { __('versions.isLatest') }
+        {:else }
+          <Icon name="warning" />
+          { __('versions.newReleaseAvailable') }
+        {/if}
+      </h3>
 
-{:then { isLatest, latest } }
-  <section class="card">
-    <h3 class="card-header card-title">
-      {#if isLatest }
-        <Icon name="ok" />
-        { __('versions.isLatest') }
-      {:else }
-        <Icon name="warning" />
-        { __('versions.newReleaseAvailable') }
-      {/if}
-    </h3>
-
-    <div class="card-content grid">
-      <div class="current">
-        <Prop 
-          label={ __('versions.current') }
-          value={ $status.version }
-        />
-      </div>
-      {#if !isLatest }
-        <div class="latest">
-          <Prop label={ __('versions.latest') }>
-            <svelte:fragment slot="value">
-              { latest.version } <br/>
-              { __('versions.published') } { new Date(latest.publishedAt).toLocaleDateString() }
-            </svelte:fragment>
-          </Prop> 
+      <div class="card-content grid">
+        <div class="current">
+          <Prop 
+            label={ __('versions.current') }
+            value={ $status.version }
+          />
         </div>
-      {/if}
-    </div>
-  </section>
+        {#if !isLatest }
+          <div class="latest">
+            <Prop label={ __('versions.latest') }>
+              <svelte:fragment slot="value">
+                { latest.version } <br/>
+                { __('versions.published') } { new Date(latest.publishedAt).toLocaleDateString() }
+              </svelte:fragment>
+            </Prop> 
+          </div>
+        {/if}
+      </div>
+    </section>
 
 
-{:catch error }
-  {#if error?.config?.url === githubLatestReleaseUrl }
-    <ErrorCard code={ ErrorCode.GITHUB_API_LIMIT_EXCEEDED } />
-    <CurrentVersion />
-  {:else }
-    <ErrorCard code={ ErrorCode.API_NOT_RESPONDING } />
+  {:catch error }
+    {#if error?.config?.url === githubLatestReleaseUrl }
+      <ErrorCard code={ ErrorCode.GITHUB_API_LIMIT_EXCEEDED } />
+      <CurrentVersion />
+    {:else }
+      <ErrorCard code={ ErrorCode.API_NOT_RESPONDING } />
 
-  {/if}
+    {/if}
 
-{/await}
+  {/await}
+{/if}
 
 
 

--- a/src/components/blocks/status/CatchingUp.svelte
+++ b/src/components/blocks/status/CatchingUp.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import __ from "$lib/locales";
+  import { env } from "$env/dynamic/public";
+  import { round } from "lodash-es";
+  import { onDestroy, onMount } from "svelte";
+  import { writable } from 'svelte/store';
+  import { formatAmount } from "$lib/helpers/format";
+  import { parseMetricsResponse } from "$lib/helpers/responses";
+  import AlgodApi from "$lib/api/algod";
+  import axios from "axios";
+  import Icon from "$components/icons/Icon.svelte";
+  
+  let localInterval: NodeJS.Timeout;
+  let remoteInterval: NodeJS.Timeout;
+
+  const catchup = writable({
+    currentRound: 0,
+    totalRounds: 0,
+  });
+  
+  onDestroy(destroy);
+  function destroy() {
+    if (localInterval) clearTimeout(localInterval);
+    if (remoteInterval) clearTimeout(remoteInterval);
+  }
+  
+  onMount(init);
+  function init() {
+    getLocalSyncedCount();
+    if (env.PUBLIC_ALLOW_EXTERNAL_APIS) getRemoteBlockCount();
+  }
+  
+  /**
+  * Get local sync count
+  * Runs every 2 seconds
+  * ==================================================
+  */
+  async function getLocalSyncedCount() {
+    if (localInterval) clearTimeout(localInterval);
+    try {
+      const response = await AlgodApi.private.get('/metrics') as string;
+      const metrics = parseMetricsResponse(response);
+      catchup.update($catchup => ({
+        ...$catchup,
+        currentRound: metrics.algod_ledger_round,
+      }))
+    }
+    catch {}
+    localInterval = setTimeout(getLocalSyncedCount, 2000);
+  }
+
+  /**
+  * Get the blockchain latest block from Algonode
+  * Runs every 30 seconds 
+  * ==================================================
+  */
+  async function getRemoteBlockCount() {
+    if (remoteInterval) clearTimeout(remoteInterval);
+    try {
+      const { data: status } = await axios.get('https://mainnet-api.algonode.cloud/v2/status');
+      catchup.update($catchup => ({
+        ...$catchup,
+        totalRounds: status['last-round'],
+      }))
+    }
+    catch {}
+    remoteInterval = setTimeout(getRemoteBlockCount, 30000);
+  }
+</script>
+
+
+
+
+<section class="card">
+  <h2 class="card-title card-header">
+    <Icon name="sync" />
+    { __('status.catchingUp') }
+  </h2>
+
+  <div class="card-content">
+    {#if env.PUBLIC_ALLOW_EXTERNAL_APIS }
+      <div class="progress">
+        <div 
+          class="bar" 
+          style:width={(
+          $catchup.currentRound
+            ? round($catchup.currentRound / $catchup.totalRounds * 100, 2)
+            : 0
+          ) + '%' } 
+        />
+      </div>
+
+      <div class="status data-value">
+        { __('status.synced') } { formatAmount($catchup.currentRound) } 
+        / { formatAmount($catchup.totalRounds) } { __('status.totalBlocks') }
+      </div>
+
+    {:else }
+      <div class="status data-value">
+        { __('status.synced') } { formatAmount($catchup.currentRound) } { __('status.blocks') }
+      </div>
+
+    {/if}
+  </div>
+</section>
+
+
+
+<style lang="scss">
+  .progress {
+    height: 2em;
+    border-radius: var(--radius);
+    border: 1px solid var(--border-color);
+    padding: 3px;
+    .bar {
+      height: 100%;
+      background: var(--primary);
+      border-radius: var(--inner-radius);
+      transition: width 1s var(--ease);
+      min-width: 10px
+    }
+  }
+  .status {
+    margin-top: 1em;
+  }
+</style>

--- a/src/components/blocks/status/CatchingUp.svelte
+++ b/src/components/blocks/status/CatchingUp.svelte
@@ -74,7 +74,7 @@
 <section class="card">
   <h2 class="card-title card-header">
     <Icon name="sync" />
-    { __('status.catchingUp') }
+    { __('status.catchingUpTitle') }
   </h2>
 
   <div class="card-content">

--- a/src/components/blocks/status/CatchingUp.svelte
+++ b/src/components/blocks/status/CatchingUp.svelte
@@ -10,8 +10,8 @@
   import axios from "axios";
   import Icon from "$components/icons/Icon.svelte";
   
-  let localInterval: NodeJS.Timeout;
-  let remoteInterval: NodeJS.Timeout;
+  let localTimeout: NodeJS.Timeout;
+  let remoteTimeout: NodeJS.Timeout;
 
   const catchup = writable({
     currentRound: 0,
@@ -20,8 +20,8 @@
   
   onDestroy(destroy);
   function destroy() {
-    if (localInterval) clearTimeout(localInterval);
-    if (remoteInterval) clearTimeout(remoteInterval);
+    if (localTimeout) clearTimeout(localTimeout);
+    if (remoteTimeout) clearTimeout(remoteTimeout);
   }
   
   onMount(init);
@@ -36,7 +36,7 @@
   * ==================================================
   */
   async function getLocalSyncedCount() {
-    if (localInterval) clearTimeout(localInterval);
+    if (localTimeout) clearTimeout(localTimeout);
     try {
       const response = await AlgodApi.private.get('/metrics') as string;
       const metrics = parseMetricsResponse(response);
@@ -44,9 +44,9 @@
         ...$catchup,
         currentRound: metrics.algod_ledger_round,
       }))
+      localTimeout = setTimeout(getLocalSyncedCount, 2000);
     }
     catch {}
-    localInterval = setTimeout(getLocalSyncedCount, 2000);
   }
 
   /**
@@ -55,7 +55,7 @@
   * ==================================================
   */
   async function getRemoteBlockCount() {
-    if (remoteInterval) clearTimeout(remoteInterval);
+    if (remoteTimeout) clearTimeout(remoteTimeout);
     try {
       const { data: status } = await axios.get('https://mainnet-api.algonode.cloud/v2/status');
       catchup.update($catchup => ({
@@ -64,7 +64,7 @@
       }))
     }
     catch {}
-    remoteInterval = setTimeout(getRemoteBlockCount, 30000);
+    remoteTimeout = setTimeout(getRemoteBlockCount, 30000);
   }
 </script>
 

--- a/src/components/blocks/status/Offline.svelte
+++ b/src/components/blocks/status/Offline.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  
+</script>
+
+<style lang="scss">
+  
+</style>

--- a/src/components/blocks/status/Offline.svelte
+++ b/src/components/blocks/status/Offline.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  
+  import __ from "$lib/locales";
+  import ErrorCard from "$components/elements/ErrorCard.svelte";
 </script>
 
-<style lang="scss">
-  
-</style>
+<ErrorCard message={ __('status.offlineTitle') } />
+

--- a/src/components/elements/ErrorCard.svelte
+++ b/src/components/elements/ErrorCard.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-    import Icon from "$components/icons/Icon.svelte";
+  import Icon from "$components/icons/Icon.svelte";
   import { ErrorCode } from "$lib/enums";
   import __ from "$lib/locales";
   export let code: ErrorCode|undefined = undefined;
-  export let message: string|undefined = undefined; 
+  export let message: string|undefined = undefined;
+  console.log(message) 
     
   const content = message 
     ? message 

--- a/src/components/elements/NodeStatus.svelte
+++ b/src/components/elements/NodeStatus.svelte
@@ -1,12 +1,29 @@
 <script lang="ts">
   import { round } from 'lodash-es';
+  import { NodeState } from '$lib/enums';
+  import __ from '$lib/locales';
   import status from '$lib/stores/status';
   import Spinner from '$components/elements/Spinner.svelte';
+  $: console.log($status)
 </script>
 
 
-{#if $status}
-  <div class="status">
+<div class="status">
+  {#if $status.state === NodeState.LOADING }
+    <Spinner />
+
+
+  {:else if $status.state === NodeState.OFFLINE }
+    <span class="info error">
+      { __('status.isOffline') } 
+    </span>
+
+  {:else if $status.state === NodeState.CATCHING_UP }
+    <span class="info error">
+      { __('status.isCatchingUp') } 
+    </span>
+
+  {:else if $status.state === NodeState.READY }
     {#if $status.version }
       <span class="info">
         { $status.version } 
@@ -26,11 +43,9 @@
     {:else}
       <Spinner />
     {/if }
-  </div>
-
-{:else }
-  <div></div>
-{/if}
+    
+  {/if}
+</div>
 
 <style lang="scss">
   .status {

--- a/src/components/elements/NodeStatus.svelte
+++ b/src/components/elements/NodeStatus.svelte
@@ -4,7 +4,6 @@
   import __ from '$lib/locales';
   import status from '$lib/stores/status';
   import Spinner from '$components/elements/Spinner.svelte';
-  $: console.log($status)
 </script>
 
 

--- a/src/components/icons/list.ts
+++ b/src/components/icons/list.ts
@@ -6,6 +6,8 @@ import pera from '$assets/logos/pera.svg?raw';
 import discord from '$fa/brands/discord.svg?raw';
 import twitter from '$fa/brands/twitter.svg?raw';
 
+
+import arrowsRotate from '$fa/solid/arrows-rotate.svg?raw';
 import chartNetwork from '$fa/solid/globe.svg?raw';
 import circleCheck from '$fa/solid/circle-check.svg?raw';
 import chevronRight from '$fa/solid/chevron-right.svg?raw';
@@ -44,6 +46,7 @@ const list: Record<string, string> = {
   select: sort,
   sort,
   sun,
+  sync: arrowsRotate,
   user,
   vote: squareCheck,
   warning: triangleExclamation,

--- a/src/lib/api/algod.ts
+++ b/src/lib/api/algod.ts
@@ -101,7 +101,6 @@ export default abstract class AlgodApi {
   * ==================================================
   */
   private static handleError(e: unknown) {
-    console.log('ERROR', e);
     return { error: true, data: e }
   }
 }

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -1,6 +1,7 @@
-
-
-
+/**
+* API Methods
+* ==================================================
+*/
 export enum Method {
   GET = 'get',
   POST = 'post',
@@ -8,11 +9,47 @@ export enum Method {
   DELETE = 'delete',
 }
 
+/**
+* Props
+* ==================================================
+*/
 export enum PropType {
   BLOCK = 'block',
   ADDRESS = 'address',
   AMOUNT = 'amount',
 }
+
+
+/**
+* Node Status
+* ==================================================
+*/
+export enum NodeState  {
+  LOADING,
+  ERROR, 
+  OFFLINE,
+  CATCHING_UP,
+  READY,
+}
+
+/**
+* Error codes 
+* ==================================================
+*/
+export enum ErrorCode {
+  DEFAULT,
+  REQUIRED,
+  NOT_A_STRING,
+  NOT_A_NUMBER,
+  NOT_AN_EMAIL,
+  NOT_AN_ADDRESS,
+  NOT_AN_URL,
+  NOT_AN_OPTION,
+  API_NOT_RESPONDING,
+  GITHUB_API_LIMIT_EXCEEDED,
+}
+
+
 
 
 
@@ -43,21 +80,3 @@ export enum Sizes {
   HUGE = 'huge',
 }
 
-
-
-/**
-* Error codes 
-* ==================================================
-*/
-export enum ErrorCode {
-  DEFAULT,
-  REQUIRED,
-  NOT_A_STRING,
-  NOT_A_NUMBER,
-  NOT_AN_EMAIL,
-  NOT_AN_ADDRESS,
-  NOT_AN_URL,
-  NOT_AN_OPTION,
-  API_NOT_RESPONDING,
-  GITHUB_API_LIMIT_EXCEEDED,
-}

--- a/src/lib/helpers/responses.ts
+++ b/src/lib/helpers/responses.ts
@@ -1,0 +1,17 @@
+
+
+export function parseMetricsResponse(response: string) {
+  const metrics: Record<string, number> = {};
+  response
+    .replace(/^#.+/gm, '') // remove comments
+    .replace(/\n+/g, '\n') // merge multiple new lines
+    .replace(/^\n/g, '') // remove empty new line
+    .replace(/{}/g, '') // remove curly braces
+    .split('\n')
+    .forEach((str: string) => {
+      const [key, value] = str.split(' ');
+      metrics[key] = Number(value);
+    });
+
+  return metrics
+}

--- a/src/lib/locales/index.ts
+++ b/src/lib/locales/index.ts
@@ -5,6 +5,7 @@ import forms from './forms';
 import metrics from './metrics';
 import nav from './nav';
 import participation from './participation';
+import status from './status';
 import ui from './ui';
 import versions from './versions';
 import wallet from './wallet';
@@ -21,6 +22,7 @@ export const strings = {
   metrics,
   nav,
   participation,
+  status,
   ui,
   versions,
   wallet,

--- a/src/lib/locales/status.ts
+++ b/src/lib/locales/status.ts
@@ -4,6 +4,11 @@ const strings: LocaleDictionnary =  {
   isOnline: 'Your node is online',
   isOffline: 'Your node is offline',
   isCatchingUp: 'Your node is catching up...',
+
+  catchingUp: 'Catching up to the latest block',
+  synced: 'Synced',
+  blocks: 'Blocks',
+  totalBlocks: 'Total blocks',
 }
 
 export default strings;

--- a/src/lib/locales/status.ts
+++ b/src/lib/locales/status.ts
@@ -5,7 +5,9 @@ const strings: LocaleDictionnary =  {
   isOffline: 'Your node is offline',
   isCatchingUp: 'Your node is catching up...',
 
-  catchingUp: 'Catching up to the latest block',
+  offlineTitle: 'Your node is currently offline. Turn it back on and refresh the page.',
+
+  catchingUpTitle: 'Catching up to the latest block',
   synced: 'Synced',
   blocks: 'Blocks',
   totalBlocks: 'Total blocks',

--- a/src/lib/locales/status.ts
+++ b/src/lib/locales/status.ts
@@ -1,0 +1,9 @@
+import type { LocaleDictionnary } from "$lib/types";
+
+const strings: LocaleDictionnary =  {
+  isOnline: 'Your node is online',
+  isOffline: 'Your node is offline',
+  isCatchingUp: 'Your node is catching up...',
+}
+
+export default strings;

--- a/src/lib/stores/status.ts
+++ b/src/lib/stores/status.ts
@@ -3,9 +3,8 @@ import type { SetStatusCallback, StatusProps } from "./types";
 import type { Readable } from "svelte/store";
 import { readable, get } from "svelte/store";
 import { browser } from "$app/environment";
-import AlgodApi from "$lib/api/algod";
 import { NodeState } from "$lib/enums";
-import { parseMetricsResponse } from "$lib/helpers/responses";
+import AlgodApi from "$lib/api/algod";
 /**
 * Component lifecycle
 * ==================================================
@@ -100,7 +99,7 @@ async function checkIfReady(resolve: (...args: unknown[]) => void) {
     resolve();
   }
   catch {
-    updateTimeout = setTimeout( () => checkIfReady(resolve), 3000 );
+    updateTimeout = setTimeout( () => checkIfReady(resolve), 30000 );
   }
 }
 
@@ -129,6 +128,7 @@ async function waitForInitialState(set: SetStatusCallback) {
 * ==================================================
 */
 async function waitForNewRound(set: SetStatusCallback) {
+  if (updateTimeout) clearTimeout(updateTimeout);
   let { lastRound, lastTimestamp, averageBlockTime, blockTime, sampleSize } = get(status);
   const statusResponse = await AlgodApi.private.get(`/v2/status/wait-for-block-after/${lastRound}`) as NodeStatusResponse;
   if (!started) return; // dirty fix for HMR initializing store multiple times.

--- a/src/lib/stores/types.ts
+++ b/src/lib/stores/types.ts
@@ -1,4 +1,7 @@
+import type { NodeState } from "$lib/enums";
+
 export interface StatusProps {
+  state: NodeState,
   version: string|undefined,
   lastRound: number|undefined,
   lastTimestamp: number|undefined,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 	import TopBar from '$components/layout/TopBar.svelte';
 	import status from '$lib/stores/status';
 	import CatchingUp from '$components/blocks/status/CatchingUp.svelte';
+	import Offline from '$components/blocks/status/Offline.svelte';
 	
 	/**
 	* Profile
@@ -42,7 +43,10 @@
 		<TopBar />
 		<main>
 			
-			{#if $status.state === NodeState.CATCHING_UP }
+			{#if $status.state === NodeState.OFFLINE }
+				<Offline />
+
+			{:else if $status.state === NodeState.CATCHING_UP }
 				<CatchingUp />
 			
 			{:else if $status.state === NodeState.READY }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,9 +2,12 @@
 	import '../styles/global.scss';
 	import { setContext } from 'svelte';
 	import { browser } from "$app/environment";
+	import { NodeState } from '$lib/enums';
 	import Profile from '$lib/profile';
 	import MainNav from '$components/layout/MainNav.svelte';
 	import TopBar from '$components/layout/TopBar.svelte';
+	import status from '$lib/stores/status';
+	import CatchingUp from '$components/blocks/status/CatchingUp.svelte';
 	
 	/**
 	* Profile
@@ -18,7 +21,8 @@
   $: if (browser) document.documentElement.setAttribute('theme', $userTheme);
 
 	/*
-	 * [DEV] clear console on Hot Module Reload
+  * [DEV] clear console on Hot Module Reload
+	* ==================================================
 	*/
 	if (import.meta.hot) {
 		import.meta.hot.on(
@@ -27,6 +31,8 @@
 			() => console.clear()
 		);
 	}
+
+
 </script>
 
 
@@ -35,7 +41,16 @@
 	<div class="content">
 		<TopBar />
 		<main>
-			<slot></slot>
+			
+			{#if $status.state === NodeState.CATCHING_UP }
+				<CatchingUp />
+			
+			{:else if $status.state === NodeState.READY }
+				<slot></slot>
+
+			{/if}
+		
+		
 		</main>
 	</div>
 </div>


### PR DESCRIPTION
### Added
- Catchup pogress
- Layout only displays main content if status is `READY`
- Feature flag to connect to external APIs (Algonode, currently to fetch the latest block when checking catchup progress)
- Status store is now tracking the global node state (`OFFLINE`, `CATCHING_UP`, `READY`)